### PR TITLE
feat: Add green orb icons and fix Wayland window dragging

### DIFF
--- a/src/turbo_whisper/icons.py
+++ b/src/turbo_whisper/icons.py
@@ -1,9 +1,8 @@
 """Lucide icons for Turbo Whisper UI."""
 
-from PyQt6.QtCore import QByteArray, QSize
-from PyQt6.QtGui import QIcon, QPixmap
+from PyQt6.QtCore import QByteArray
+from PyQt6.QtGui import QIcon, QPainter, QPixmap
 from PyQt6.QtSvg import QSvgRenderer
-from PyQt6.QtGui import QPainter
 
 
 def _svg_to_icon(svg_content: str, size: int = 24, color: str = "#888888") -> QIcon:
@@ -31,39 +30,39 @@ def _svg_to_icon(svg_content: str, size: int = 24, color: str = "#888888") -> QI
 
 
 # Lucide icon SVGs (24x24 viewBox, stroke-based)
-ICON_POWER = '''<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+ICON_POWER = """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="M12 2v10"/>
   <path d="M18.4 6.6a9 9 0 1 1-12.77.04"/>
-</svg>'''
+</svg>"""
 
-ICON_COPY = '''<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+ICON_COPY = """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <rect width="14" height="14" x="8" y="8" rx="2" ry="2"/>
   <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>
-</svg>'''
+</svg>"""
 
-ICON_EYE = '''<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+ICON_EYE = """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/>
   <circle cx="12" cy="12" r="3"/>
-</svg>'''
+</svg>"""
 
-ICON_EYE_OFF = '''<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+ICON_EYE_OFF = """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"/>
   <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242"/>
   <path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"/>
   <path d="m2 2 20 20"/>
-</svg>'''
+</svg>"""
 
-ICON_CHEVRON_DOWN = '''<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+ICON_CHEVRON_DOWN = """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="m6 9 6 6 6-6"/>
-</svg>'''
+</svg>"""
 
-ICON_CHEVRON_UP = '''<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+ICON_CHEVRON_UP = """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="m18 15-6-6-6 6"/>
-</svg>'''
+</svg>"""
 
-ICON_CHECK = '''<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+ICON_CHECK = """<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <path d="M20 6 9 17l-5-5"/>
-</svg>'''
+</svg>"""
 
 
 def get_close_icon(size: int = 20, color: str = "#888888") -> QIcon:
@@ -99,3 +98,37 @@ def get_chevron_up_icon(size: int = 20, color: str = "#888888") -> QIcon:
 def get_check_icon(size: int = 20, color: str = "#888888") -> QIcon:
     """Get the check/tick icon."""
     return _svg_to_icon(ICON_CHECK, size, color)
+
+
+def get_tray_icon(size: int = 64) -> QIcon:
+    """Get a green orb icon for the system tray."""
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtGui import QImage, QRadialGradient, QBrush
+
+    # Create image with transparency
+    image = QImage(size, size, QImage.Format.Format_ARGB32)
+    image.fill(Qt.GlobalColor.transparent)
+
+    painter = QPainter(image)
+    painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+    # Create radial gradient for glowing orb effect
+    from PyQt6.QtGui import QColor
+
+    center = size // 2
+    gradient = QRadialGradient(center, center, center * 0.8)
+    gradient.setColorAt(0.0, QColor(180, 230, 100))  # Light green center
+    gradient.setColorAt(0.5, QColor(132, 204, 22))   # Lime green (#84cc16)
+    gradient.setColorAt(1.0, QColor(60, 100, 10))    # Darker edge
+
+    painter.setBrush(QBrush(gradient))
+    painter.setPen(Qt.PenStyle.NoPen)
+
+    # Draw the orb (circle with padding)
+    padding = size // 8
+    painter.drawEllipse(padding, padding, size - 2 * padding, size - 2 * padding)
+
+    painter.end()
+
+    pixmap = QPixmap.fromImage(image)
+    return QIcon(pixmap)

--- a/src/turbo_whisper/main.py
+++ b/src/turbo_whisper/main.py
@@ -3,8 +3,8 @@
 import sys
 import threading
 
-from PyQt6.QtCore import QObject, Qt, pyqtSignal, QTimer
-from PyQt6.QtGui import QAction, QIcon, QLinearGradient, QPalette, QBrush, QColor
+from PyQt6.QtCore import QObject, Qt, QTimer, pyqtSignal
+from PyQt6.QtGui import QAction, QIcon
 from PyQt6.QtWidgets import (
     QApplication,
     QHBoxLayout,
@@ -31,6 +31,7 @@ from .icons import (
     get_copy_icon,
     get_eye_icon,
     get_eye_off_icon,
+    get_tray_icon,
 )
 from .recorder import AudioRecorder
 from .typer import Typer
@@ -61,6 +62,9 @@ class RecordingWindow(QWidget):
 
     def _setup_ui(self) -> None:
         """Set up the recording window UI."""
+        # Set window icon for taskbar
+        self.setWindowIcon(get_tray_icon(128))
+
         # Frameless, always on top, floating window
         self.setWindowFlags(
             Qt.WindowType.FramelessWindowHint
@@ -74,7 +78,8 @@ class RecordingWindow(QWidget):
         # Main container with rounded corners and purple gradient
         container = QWidget(self)
         container.setObjectName("container")
-        container.setStyleSheet("""
+        container.setStyleSheet(
+            """
             #container {
                 background: qlineargradient(
                     x1:0, y1:0, x2:1, y2:1,
@@ -85,10 +90,11 @@ class RecordingWindow(QWidget):
                 border-radius: 12px;
                 border: 1px solid #4a3070;
             }
-        """)
+        """
+        )
 
         # Use a stacked layout - waveform behind, controls on top
-        from PyQt6.QtWidgets import QStackedLayout, QFrame
+        from PyQt6.QtWidgets import QFrame
 
         # Container layout
         container_layout = QVBoxLayout(container)
@@ -118,10 +124,12 @@ class RecordingWindow(QWidget):
         status_layout.setContentsMargins(4, 0, 4, 0)
 
         self.status_label = QLabel("Listening...")
-        self.status_label.setStyleSheet("""
+        self.status_label.setStyleSheet(
+            """
             color: #888;
             font-size: 11px;
-        """)
+        """
+        )
         status_layout.addWidget(self.status_label)
 
         status_layout.addStretch()
@@ -129,10 +137,12 @@ class RecordingWindow(QWidget):
         # Hint label - show configured hotkey
         hotkey_str = "+".join(k.title() for k in self.config.hotkey)
         hints = QLabel(f"Stop: {hotkey_str}")
-        hints.setStyleSheet("""
+        hints.setStyleSheet(
+            """
             color: #666;
             font-size: 10px;
-        """)
+        """
+        )
         status_layout.addWidget(hints)
 
         # Animated status timer
@@ -147,7 +157,8 @@ class RecordingWindow(QWidget):
         self.settings_btn = QPushButton()
         self.settings_btn.setIcon(get_chevron_down_icon(20, "#84cc16"))
         self.settings_btn.setFixedSize(40, 28)
-        self.settings_btn.setStyleSheet("""
+        self.settings_btn.setStyleSheet(
+            """
             QPushButton {
                 background: rgba(132, 204, 22, 0.1);
                 border: 1px solid rgba(132, 204, 22, 0.3);
@@ -156,13 +167,15 @@ class RecordingWindow(QWidget):
             QPushButton:hover {
                 background: rgba(132, 204, 22, 0.2);
             }
-        """)
+        """
+        )
         self.settings_btn.clicked.connect(self._toggle_settings)
         layout.addWidget(self.settings_btn, alignment=Qt.AlignmentFlag.AlignCenter)
 
         # Collapsible settings panel
         self.settings_panel = QWidget()
-        self.settings_panel.setStyleSheet("""
+        self.settings_panel.setStyleSheet(
+            """
             QWidget {
                 background-color: rgba(0, 0, 0, 0.3);
                 border-radius: 8px;
@@ -190,27 +203,11 @@ class RecordingWindow(QWidget):
                 margin: -4px 0;
                 border-radius: 7px;
             }
-        """)
+        """
+        )
         settings_layout = QVBoxLayout(self.settings_panel)
         settings_layout.setContentsMargins(12, 8, 12, 8)
         settings_layout.setSpacing(8)
-
-        # Small button style for copy/show buttons
-        small_btn_style = """
-            QPushButton {
-                background-color: rgba(255, 255, 255, 0.1);
-                color: #888;
-                border: 1px solid rgba(255, 255, 255, 0.1);
-                border-radius: 3px;
-                font-size: 10px;
-                padding: 4px 8px;
-            }
-            QPushButton:hover {
-                background-color: rgba(132, 204, 22, 0.2);
-                color: #84cc16;
-                border-color: rgba(132, 204, 22, 0.3);
-            }
-        """
 
         # API URL
         url_label = QLabel("API URL")
@@ -221,7 +218,8 @@ class RecordingWindow(QWidget):
         self.url_copy_btn.setIcon(get_copy_icon(16, "#888888"))
         self.url_copy_btn.setFixedSize(28, 28)
         self.url_copy_btn.setToolTip("Copy to clipboard")
-        self.url_copy_btn.setStyleSheet("""
+        self.url_copy_btn.setStyleSheet(
+            """
             QPushButton {
                 background-color: rgba(255, 255, 255, 0.1);
                 border: 1px solid rgba(255, 255, 255, 0.1);
@@ -231,8 +229,11 @@ class RecordingWindow(QWidget):
                 background-color: rgba(132, 204, 22, 0.2);
                 border-color: rgba(132, 204, 22, 0.3);
             }
-        """)
-        self.url_copy_btn.clicked.connect(lambda: self._copy_to_clipboard(self.api_url_input.text(), self.url_copy_btn))
+        """
+        )
+        self.url_copy_btn.clicked.connect(
+            lambda: self._copy_to_clipboard(self.api_url_input.text(), self.url_copy_btn)
+        )
         url_row.addWidget(self.api_url_input)
         url_row.addWidget(self.url_copy_btn)
         settings_layout.addWidget(url_label)
@@ -248,7 +249,8 @@ class RecordingWindow(QWidget):
         self.api_key_input.setPlaceholderText("sk-...")
         self.api_key_input.textChanged.connect(self._on_api_key_changed)
         # Style to ensure asterisks show clearly
-        self.api_key_input.setStyleSheet("""
+        self.api_key_input.setStyleSheet(
+            """
             QLineEdit {
                 background-color: rgba(255, 255, 255, 0.1);
                 border: 1px solid #4a3070;
@@ -258,13 +260,15 @@ class RecordingWindow(QWidget):
                 font-size: 12px;
                 font-family: monospace;
             }
-        """)
+        """
+        )
         # Eye icon button for show/hide
         self.key_visible_btn = QPushButton()
         self.key_visible_btn.setIcon(get_eye_icon(16, "#888888"))
         self.key_visible_btn.setFixedSize(28, 28)
         self.key_visible_btn.setToolTip("Show/hide API key")
-        self.key_visible_btn.setStyleSheet("""
+        self.key_visible_btn.setStyleSheet(
+            """
             QPushButton {
                 background-color: rgba(255, 255, 255, 0.1);
                 border: 1px solid rgba(255, 255, 255, 0.1);
@@ -274,14 +278,16 @@ class RecordingWindow(QWidget):
                 background-color: rgba(132, 204, 22, 0.2);
                 border-color: rgba(132, 204, 22, 0.3);
             }
-        """)
+        """
+        )
         self.key_visible_btn.clicked.connect(self._toggle_key_visibility)
         # Copy icon button
         self.key_copy_btn = QPushButton()
         self.key_copy_btn.setIcon(get_copy_icon(16, "#888888"))
         self.key_copy_btn.setFixedSize(28, 28)
         self.key_copy_btn.setToolTip("Copy to clipboard")
-        self.key_copy_btn.setStyleSheet("""
+        self.key_copy_btn.setStyleSheet(
+            """
             QPushButton {
                 background-color: rgba(255, 255, 255, 0.1);
                 border: 1px solid rgba(255, 255, 255, 0.1);
@@ -291,8 +297,11 @@ class RecordingWindow(QWidget):
                 background-color: rgba(132, 204, 22, 0.2);
                 border-color: rgba(132, 204, 22, 0.3);
             }
-        """)
-        self.key_copy_btn.clicked.connect(lambda: self._copy_to_clipboard(self._actual_api_key, self.key_copy_btn))
+        """
+        )
+        self.key_copy_btn.clicked.connect(
+            lambda: self._copy_to_clipboard(self._actual_api_key, self.key_copy_btn)
+        )
         key_row.addWidget(self.api_key_input)
         key_row.addWidget(self.key_visible_btn)
         key_row.addWidget(self.key_copy_btn)
@@ -317,7 +326,8 @@ class RecordingWindow(QWidget):
         self.history_list.setMaximumHeight(200)
         self.history_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self.history_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self.history_list.setStyleSheet("""
+        self.history_list.setStyleSheet(
+            """
             QListWidget {
                 background-color: rgba(255, 255, 255, 0.05);
                 border: 1px solid #4a3070;
@@ -336,14 +346,16 @@ class RecordingWindow(QWidget):
                 background-color: rgba(132, 204, 22, 0.2);
                 color: #84cc16;
             }
-        """)
+        """
+        )
         self.history_list.itemClicked.connect(self._on_history_item_clicked)
         self._refresh_history()
         settings_layout.addWidget(self.history_list)
 
         # Save button - at the bottom, vibrant green
         self.save_btn = QPushButton("Save Settings")
-        self.save_btn.setStyleSheet("""
+        self.save_btn.setStyleSheet(
+            """
             QPushButton {
                 background-color: #84cc16;
                 color: #000;
@@ -356,7 +368,8 @@ class RecordingWindow(QWidget):
             QPushButton:hover {
                 background-color: #9ae62a;
             }
-        """)
+        """
+        )
         self.save_btn.clicked.connect(self._save_settings)
         settings_layout.addWidget(self.save_btn)
 
@@ -373,7 +386,8 @@ class RecordingWindow(QWidget):
         self.close_btn.setIcon(get_close_icon(14, "#666666"))
         self.close_btn.setFixedSize(20, 20)
         self.close_btn.setToolTip("Close")
-        self.close_btn.setStyleSheet("""
+        self.close_btn.setStyleSheet(
+            """
             QPushButton {
                 background: transparent;
                 border: none;
@@ -382,18 +396,21 @@ class RecordingWindow(QWidget):
                 background: rgba(255, 255, 255, 0.1);
                 border-radius: 4px;
             }
-        """)
+        """
+        )
         self.close_btn.clicked.connect(self._close_window)
         self.close_btn.move(self.config.window_width - 28, 8)  # Top-right corner
         self.close_btn.raise_()  # Bring to front
 
         # Version label - overlaid in top-left corner (not in layout)
         self.version_label = QLabel("v0.1.0", container)
-        self.version_label.setStyleSheet("""
+        self.version_label.setStyleSheet(
+            """
             color: #555;
             font-size: 9px;
             background: transparent;
-        """)
+        """
+        )
         self.version_label.move(12, 10)
         self.version_label.raise_()
 
@@ -516,11 +533,18 @@ class RecordingWindow(QWidget):
     def mousePressEvent(self, event) -> None:
         """Handle mouse press for dragging."""
         if event.button() == Qt.MouseButton.LeftButton:
-            self._drag_pos = event.globalPosition().toPoint() - self.frameGeometry().topLeft()
+            # Use startSystemMove for Wayland compatibility
+            if hasattr(self.windowHandle(), "startSystemMove"):
+                self.windowHandle().startSystemMove()
+            else:
+                # Fallback for X11
+                self._drag_pos = (
+                    event.globalPosition().toPoint() - self.frameGeometry().topLeft()
+                )
             event.accept()
 
     def mouseMoveEvent(self, event) -> None:
-        """Handle mouse move for dragging."""
+        """Handle mouse move for dragging (X11 fallback)."""
         if event.buttons() == Qt.MouseButton.LeftButton and self._drag_pos is not None:
             self.move(event.globalPosition().toPoint() - self._drag_pos)
             event.accept()
@@ -575,7 +599,7 @@ class TurboWhisper:
         self.tray = QSystemTrayIcon(self.app)
 
         # Create simple icon (will use default if no icon available)
-        self.tray.setIcon(QIcon.fromTheme("audio-input-microphone"))
+        self.tray.setIcon(get_tray_icon(64))
         self.tray.setToolTip("Turbo Whisper - Press Alt+Space to dictate")
 
         # Context menu
@@ -694,7 +718,7 @@ class TurboWhisper:
         if self._pending_waveform_data is not None:
             level, waveform_buffer = self._pending_waveform_data
             # Debug: print level occasionally
-            if hasattr(self, '_poll_count'):
+            if hasattr(self, "_poll_count"):
                 self._poll_count += 1
             else:
                 self._poll_count = 0


### PR DESCRIPTION
## Summary
- Add custom green orb icon for system tray (64px)
- Add custom green orb icon for taskbar/window (128px)
- Fix window dragging on Wayland using `startSystemMove()`
- Code formatting with black/ruff

## Changes
- `icons.py`: Added `get_tray_icon()` function that creates a green radial gradient orb
- `main.py`: Set window icon and tray icon to use new green orb, fixed Wayland dragging

## Test plan
- [x] Verify green orb appears in system tray
- [x] Verify green orb appears in taskbar/window switcher
- [x] Verify window can be dragged on Wayland

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)