### PR TITLE
feat: add optional push-to-talk hold mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Create `~/.config/turbo-whisper/config.json` (Linux/macOS) or `%APPDATA%\turbo-w
   "api_url": "https://api.openai.com/v1/audio/transcriptions",
   "api_key": "sk-your-api-key",
   "hotkey": ["ctrl", "shift", "space"],
+  "push_to_talk": false,
   "language": "en",
   "auto_paste": true,
   "copy_to_clipboard": true,
@@ -233,16 +234,16 @@ source .venv/bin/activate  # Linux/macOS
 turbo-whisper
 ```
 
-1. Press **Ctrl+Shift+Space** to start recording
+1. Press your configured hotkey to start recording
 2. Speak your text
-3. Press **Ctrl+Shift+Space** again to stop and transcribe
+3. Press the hotkey again to stop and transcribe
 4. Text is automatically typed into the focused window (wherever your cursor is)
 
 ### Keyboard Shortcuts
 
 | Shortcut | Action |
 |----------|--------|
-| Ctrl+Shift+Space | Start/stop recording (configurable) |
+| Configurable hotkey | Start/stop recording |
 | Esc | Cancel recording (when window is focused) |
 
 ### Custom Hotkey
@@ -250,11 +251,21 @@ turbo-whisper
 Edit your config to change the hotkey:
 ```json
 {
-  "hotkey": ["ctrl", "alt", "w"]
+  "hotkey": ["ctrl", "alt", "w"],
+  "push_to_talk": false
 }
 ```
 
 Available modifiers: `ctrl`, `shift`, `alt`, `super`
+
+Enable hold-to-talk (press and hold to record, release to stop):
+
+```json
+{
+  "hotkey": ["alt"],
+  "push_to_talk": true
+}
+```
 
 ### Autostart on Login
 

--- a/config.example.json
+++ b/config.example.json
@@ -2,6 +2,7 @@
   "api_url": "https://api.openai.com/v1/audio/transcriptions",
   "api_key": "sk-your-api-key-here",
   "hotkey": ["alt", "space"],
+  "push_to_talk": false,
   "sample_rate": 16000,
   "channels": 1,
   "chunk_size": 1024,

--- a/src/turbo_whisper/config.py
+++ b/src/turbo_whisper/config.py
@@ -41,6 +41,11 @@ class Config:
     #          Alt+Space on Linux/macOS
     hotkey: list[str] = field(default_factory=_default_hotkey)
 
+    # Dictation interaction mode
+    # False: press once to start, press again to stop
+    # True: hold keys to record, release to stop
+    push_to_talk: bool = False
+
     # Audio settings
     sample_rate: int = 16000
     channels: int = 1

--- a/src/turbo_whisper/hotkey.py
+++ b/src/turbo_whisper/hotkey.py
@@ -41,14 +41,20 @@ def _format_hotkey_for_portal(hotkey_combo: list[str]) -> str:
 class PortalHotkeyManager:
     """Wayland hotkey manager using xdg-desktop-portal GlobalShortcuts."""
 
-    def __init__(self, hotkey_combo: list[str], callback: Callable[[], None]):
+    def __init__(
+        self,
+        hotkey_combo: list[str],
+        on_activate: Callable[[], None],
+        on_deactivate: Callable[[], None] | None = None,
+    ):
         """Initialize portal hotkey manager."""
         # Import here to make dependencies optional
         import dbus
         from dbus.mainloop.glib import DBusGMainLoop
         from gi.repository import GLib
 
-        self.callback = callback
+        self.on_activate = on_activate
+        self.on_deactivate = on_deactivate
         self.hotkey_combo = hotkey_combo
         self.hotkey_str = _format_hotkey_for_portal(hotkey_combo)
         self._running = False
@@ -69,7 +75,7 @@ class PortalHotkeyManager:
     def _on_activated(self, session_handle, shortcut_id, timestamp, options):
         """Handle shortcut activation."""
         if shortcut_id == "turbo-whisper-toggle":
-            self.callback()
+            self.on_activate()
 
     def _on_session_created(self, response, results):
         """Handle session creation response."""
@@ -172,24 +178,32 @@ class PortalHotkeyManager:
 class HotkeyManager:
     """Manages global hotkey registration using pynput (X11/Windows/macOS)."""
 
-    def __init__(self, hotkey_combo: list[str], callback: Callable[[], None]):
+    def __init__(
+        self,
+        hotkey_combo: list[str],
+        on_activate: Callable[[], None],
+        on_deactivate: Callable[[], None] | None = None,
+    ):
         """
         Initialize hotkey manager.
 
         Args:
             hotkey_combo: List of key names, e.g., ["alt", "space"]
-            callback: Function to call when hotkey is pressed
+            on_activate: Function to call when hotkey combo is pressed
+            on_deactivate: Function to call when hotkey combo is released
         """
         # Import here to make dependency optional (only needed on non-Wayland)
         from pynput import keyboard
 
         self._keyboard = keyboard
 
-        self.callback = callback
+        self.on_activate = on_activate
+        self.on_deactivate = on_deactivate
         self.hotkey_combo = self._parse_hotkey(hotkey_combo)
         self.hotkey_chars = self._get_char_keys(hotkey_combo)
         self.current_keys = set()
         self.current_chars = set()
+        self._combo_active = False
         self.listener = None
         self._running = False
         self._last_trigger = 0
@@ -270,13 +284,10 @@ class HotkeyManager:
         if special_keys_match and char_keys_match:
             # Debounce to prevent double triggers
             now = time.time() * 1000
-            if now - self._last_trigger > self._debounce_ms:
+            if (not self._combo_active) and now - self._last_trigger > self._debounce_ms:
                 self._last_trigger = now
-                # Clear key state to ensure next press re-triggers
-                # (release events may be lost when window is shown)
-                self.current_keys.clear()
-                self.current_chars.clear()
-                self.callback()
+                self._combo_active = True
+                self.on_activate()
 
     def _on_release(self, key) -> None:
         """Handle key release event."""
@@ -294,6 +305,14 @@ class HotkeyManager:
             self.current_keys.discard(kb.Key.ctrl)
         if key in (kb.Key.shift_l, kb.Key.shift_r):
             self.current_keys.discard(kb.Key.shift)
+
+        special_keys_match = self.hotkey_combo.issubset(self.current_keys)
+        char_keys_match = self.hotkey_chars.issubset(self.current_chars)
+        combo_still_active = special_keys_match and char_keys_match
+        if self._combo_active and (not combo_still_active):
+            self._combo_active = False
+            if self.on_deactivate:
+                self.on_deactivate()
 
     def start(self) -> None:
         """Start listening for hotkeys."""
@@ -316,7 +335,9 @@ class HotkeyManager:
 
 
 def create_hotkey_manager(
-    hotkey_combo: list[str], callback: Callable[[], None]
+    hotkey_combo: list[str],
+    on_activate: Callable[[], None],
+    on_deactivate: Callable[[], None] | None = None,
 ) -> HotkeyManager | PortalHotkeyManager | None:
     """
     Create appropriate hotkey manager for the current platform.
@@ -328,8 +349,10 @@ def create_hotkey_manager(
     """
     if is_wayland():
         try:
-            manager = PortalHotkeyManager(hotkey_combo, callback)
+            manager = PortalHotkeyManager(hotkey_combo, on_activate, on_deactivate)
             print("Using xdg-desktop-portal for global hotkeys (Wayland)")
+            if on_deactivate:
+                print("Portal backend does not support release events; using press-only behavior")
             return manager
         except ImportError as e:
             print(f"Portal hotkeys unavailable (missing dependencies): {e}")
@@ -339,4 +362,4 @@ def create_hotkey_manager(
             print(f"Portal hotkeys unavailable: {e}")
             return None
     else:
-        return HotkeyManager(hotkey_combo, callback)
+        return HotkeyManager(hotkey_combo, on_activate, on_deactivate)

--- a/src/turbo_whisper/main.py
+++ b/src/turbo_whisper/main.py
@@ -996,10 +996,17 @@ class TurboWhisper:
         self._waveform_timer.setInterval(30)  # Poll at ~33 FPS
 
         # Hotkey - use appropriate backend for platform
-        self.hotkey_manager = create_hotkey_manager(
-            self.config.hotkey,
-            lambda: self.signals.toggle_recording.emit(),
-        )
+        if self.config.push_to_talk:
+            self.hotkey_manager = create_hotkey_manager(
+                self.config.hotkey,
+                self._on_hotkey_activate,
+                self._on_hotkey_deactivate,
+            )
+        else:
+            self.hotkey_manager = create_hotkey_manager(
+                self.config.hotkey,
+                self._on_hotkey_activate,
+            )
         if self.hotkey_manager is None:
             print("Warning: Global hotkeys not available on this platform")
 
@@ -1047,6 +1054,19 @@ class TurboWhisper:
         self.tray.setContextMenu(menu)
         self.tray.activated.connect(self._on_tray_activated)
         self.tray.show()
+
+    def _on_hotkey_activate(self) -> None:
+        """Handle global hotkey down/activate event."""
+        if self.config.push_to_talk:
+            if not self.is_recording:
+                self.signals.toggle_recording.emit()
+            return
+        self.signals.toggle_recording.emit()
+
+    def _on_hotkey_deactivate(self) -> None:
+        """Handle global hotkey up/deactivate event."""
+        if self.config.push_to_talk and self.is_recording:
+            self.signals.toggle_recording.emit()
 
     def _on_tray_activated(self, reason: QSystemTrayIcon.ActivationReason) -> None:
         """Handle tray icon clicks."""


### PR DESCRIPTION
## Summary
- Add optional `push_to_talk` config (`false` by default) to support hold-to-talk behavior without changing existing toggle behavior.
- Update hotkey plumbing to support separate press/release callbacks for the native hotkey manager.
- Wire main app logic so `push_to_talk=true` starts recording on key-down and stops on key-up (including single-key bindings like `[\"alt\"]`).
- Update docs/config examples to show both toggle mode and hold-to-talk mode.

## Why
On Ubuntu Wayland I needed a true hold-to-talk interaction (press and hold to record, release to finalize) instead of only press-to-toggle. This adds that behavior behind config so existing users keep current behavior.

## Risks
- Portal backend does not provide release events in this implementation, so `push_to_talk=true` may effectively behave as press-only when portal is used.
- Some key combos may still conflict with desktop/global shortcuts.
- Single-modifier binds (like `alt`) can have UX side effects depending on app/desktop behavior.

## Relation To Other PR
This is paired with a separate Wayland hotkey backend PR. Together they gave me reliable hold-to-talk + typing on Ubuntu Wayland.

## Validation
- `python3 -m py_compile src/turbo_whisper/config.py src/turbo_whisper/hotkey.py src/turbo_whisper/main.py`
- Manual validation on Ubuntu Wayland with `hotkey=[\"alt\"]` and `push_to_talk=true`.

## Note
I couldn't find a `CONTRIBUTING.md`, so I kept this scoped and conservative. If you'd like a different split/style I can adjust.


## Screenshots

_Added by the maintainer from a local test run (Kubuntu 24.04, KDE Plasma 5.27, X11). Details in the review comment below._

<table>
<tr><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr26-01-hold-listening.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr26-02-release-processing.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr26-03-second-hold.png" width="100%"></td></tr>
<tr><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr26-04-toggle-on.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr26-05-toggle-off.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr26-06-toggle-on-again.png" width="100%"></td></tr>
</table>
