### PR TITLE
fix: make transcription timeout configurable

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -14,6 +14,7 @@
   "auto_paste": true,
   "copy_to_clipboard": true,
   "language": "en",
+  "transcription_timeout": 30.0,
   "history": [],
   "history_max": 20
 }

--- a/src/turbo_whisper/api.py
+++ b/src/turbo_whisper/api.py
@@ -43,7 +43,7 @@ class WhisperClient:
         }
 
         try:
-            async with httpx.AsyncClient(timeout=30.0) as client:
+            async with httpx.AsyncClient(timeout=self.config.transcription_timeout) as client:
                 response = await client.post(
                     self.config.api_url,
                     headers=headers,
@@ -82,7 +82,7 @@ class WhisperClient:
         }
 
         try:
-            with httpx.Client(timeout=30.0) as client:
+            with httpx.Client(timeout=self.config.transcription_timeout) as client:
                 response = client.post(
                     self.config.api_url,
                     headers=headers,

--- a/src/turbo_whisper/config.py
+++ b/src/turbo_whisper/config.py
@@ -60,6 +60,9 @@ class Config:
     language: str = "en"
     typing_delay_ms: int = 5  # Milliseconds between keystrokes (increase if terminal freezes)
 
+    # Transcription settings
+    transcription_timeout: float = 30.0  # Max seconds to wait for transcription API response
+
     # Claude Code integration
     claude_integration: bool = True  # Enable integration server for Claude Code
     claude_integration_port: int = 7878  # Port for integration HTTP server


### PR DESCRIPTION
When doing a braindump which takes a little longer to transcribe it is easily possible to run into the timeout for transcribing with the local Whisper server.
This small change makes the timeout configurable. I set it to 600 on my machine and it's working fine to also transcribe 15-20 mins of audio


## Screenshots

_Added by the maintainer from a local test run (Kubuntu 24.04, KDE Plasma 5.27, X11). Details in the review comment below._

<table>
<tr><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr28-01-main-timeout-at33s.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr28-02-still-processing-at33s.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr28-03-result-typed-at40s.png" width="100%"></td></tr>
</table>
