### PR TITLE
fix: letter-key global hotkeys never fired

### DIFF
--- a/src/turbo_whisper/hotkey.py
+++ b/src/turbo_whisper/hotkey.py
@@ -263,8 +263,14 @@ class HotkeyManager:
         if key in (kb.Key.shift_l, kb.Key.shift_r):
             self.current_keys.add(kb.Key.shift)
 
-        # Check if hotkey combo is pressed (special keys + char keys)
-        special_keys_match = self.hotkey_combo.issubset(self.current_keys)
+        # Check if hotkey combo is pressed (special keys + char keys).
+        # Character keys are tracked in current_chars (not current_keys), so only
+        # the non-character members of the combo need to be in current_keys;
+        # char_keys_match below covers the letter keys. Without this, any hotkey
+        # containing a letter (e.g. super+h) silently never fires.
+        special_keys_match = all(
+            k in self.current_keys for k in self.hotkey_combo if not isinstance(k, kb.KeyCode)
+        )
         char_keys_match = self.hotkey_chars.issubset(self.current_chars)
 
         if special_keys_match and char_keys_match:


### PR DESCRIPTION
Hotkeys that include a letter never trigger. Only combos made of special keys (like the default `alt+space`) work. The README example `["ctrl","alt","w"]` is broken.

Cause: in `HotkeyManager._on_press`, `special_keys_match = self.hotkey_combo.issubset(self.current_keys)`. `hotkey_combo` includes the letter's `KeyCode`, but letter presses are tracked in `current_chars`, never `current_keys`. So the check can never be true for any combo with a letter in it.

Fix: only check the non-character members of the combo against `current_keys`. The letter part is already covered by `char_keys_match` on the next line.

Tested on X11 (Xfce): `super+h` now starts/stops recording. Before the fix, nothing happened. All-special-key combos still work.

Fixes #31



## Screenshots

_Added by the maintainer from a local test run (Kubuntu 24.04, KDE Plasma 5.27, X11). Details in the review comment below._

<table>
<tr><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr34-01-before-main.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr34-02-listening.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr34-03-transcribing.png" width="100%"></td></tr>
</table>
