### PR TITLE
fix: fall back to xdotool for typing when evdev/uinput unavailable

### DIFF
--- a/src/turbo_whisper/typer.py
+++ b/src/turbo_whisper/typer.py
@@ -195,6 +195,19 @@ class Typer:
             except Exception as e:
                 print(f"evdev typing failed: {e}")
 
+        # X11: prefer xdotool (reliable; avoids pyautogui/tkinter quirks).
+        # --clearmodifiers releases any held modifiers (e.g. a lingering Super)
+        # so the typed letters aren't interpreted as window-manager shortcuts.
+        if shutil.which("xdotool"):
+            try:
+                subprocess.run(
+                    ["xdotool", "type", "--clearmodifiers", "--delay", "5", text],
+                    check=True,
+                )
+                return True
+            except Exception as e:
+                print(f"xdotool typing failed: {e}")
+
         # Fallback to PyAutoGUI (works on X11)
         try:
             import pyautogui


### PR DESCRIPTION
On Linux the typer tries evdev UInput first. If the user isn't in the `input` group (or `/dev/uinput` isn't writable), that fails and it falls back to pyautogui, which pulls in a MouseInfo/tkinter warning on import and is fussier on some X11 setups.

This adds xdotool as the first fallback (before pyautogui), since xdotool is already a documented dependency and types reliably via XTest. evdev still wins when available. Uses `--clearmodifiers` so a held modifier doesn't turn the typed letters into WM shortcuts.

Tested on X11 without the input group: transcription text now types into the focused window (verified via xev). The evdev path is unchanged.

Note: #29 also added xdotool typing but was closed by its author (opened against upstream by mistake, not rejected on merits). This is a smaller take on the same idea, as a fallback only.

Fixes #33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds `xdotool` as the first Linux typing fallback when evdev/uinput is unavailable. It clears held modifiers before typing, which supports focused-window transcription without `input` group access.

## Worth a look

- `src/turbo_whisper/typer.py::_type_linux` — Confirm that `xdotool` is suitable for the target X11 environments and that PyAutoGUI remains the correct fallback when it is unavailable or fails.
- `src/turbo_whisper/typer.py::_type_linux` — Confirm that the fixed 5 ms `xdotool` delay handles long or fast input reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshots

_Added by the maintainer from a local test run (Kubuntu 24.04, KDE Plasma 5.27, X11). Details in the review comment below._

<table>
<tr><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr36-01-main-crash.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr36-02-xdotool.png" width="100%"></td><td width="33%"><img src="https://raw.githubusercontent.com/knowall-ai/turbo-whisper/pr-screenshots/docs/screenshots/pr36-03-dashes.png" width="100%"></td></tr>
</table>
